### PR TITLE
Dockerfile: Fix default configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY --from=builder /code/public ./public
 COPY --from=builder /code/target/release/masto-thread-renderer /usr/local/bin/
 EXPOSE 8080
 ENV ROCKET_CONFIG=/srv/masto-thread-renderer/Rocket.toml
-ENV ROCKET_PROFILE=production
+ENV ROCKET_PROFILE=release
 CMD ["/usr/local/bin/masto-thread-renderer"]


### PR DESCRIPTION
The production config in Rocket.toml is called "release" and starts on 0.0.0.0:8080. The Dockerfile expects that profile to be active, since it exposes port 8080, while the default configuration (which gets chosen with `ROCKET_PROFILE=production`) listens on 127.0.0.1:8000.

This seems to have been an oversight.

Signed-off-by: Clemens Lang <neverpanic@gmail.com>